### PR TITLE
fix: 윌버키우기 글자 표시 오류 수정 및 밥 주기 위치 조정

### DIFF
--- a/app/src/main/java/com/example/madcamp_androidapp/GameFragment.kt
+++ b/app/src/main/java/com/example/madcamp_androidapp/GameFragment.kt
@@ -201,6 +201,8 @@ class GameFragment : Fragment() {
                     
                     // 친밀도 증가시키는 거미줄 비활성화
                     webButton.isEnabled = false
+                    // 윌버 버튼도 비활성화
+                    pigButton.isEnabled = false
                     
                     if (friend < 3) {
                         // 만약 친밀도가 부족하다면 스테이크로 변함
@@ -216,6 +218,8 @@ class GameFragment : Fragment() {
                         countText.text = "샬롯이 윌버를 구해줬어요 👏\n샬롯과 윌버는 평생 행복하게 살았답니다 🤗"
                         handler.postDelayed( { countText.text = "한 번 더?\n 윌버를 눌러주세요 🐽" }, 2000)
                     }
+                    // 버튼을 눌러주세요 후에 다시 버튼 활성화
+                    handler.postDelayed( {pigButton.isEnabled = true }, 2000)
                 }
 
             }

--- a/app/src/main/res/anim/anim_moveseed.xml
+++ b/app/src/main/res/anim/anim_moveseed.xml
@@ -3,8 +3,8 @@
     <translate
         android:duration="500"
         android:fromXDelta="0"
-        android:toXDelta="-150"
+        android:toXDelta="-100"
         android:fromYDelta="0"
-        android:toYDelta="-150"/>
+        android:toYDelta="-170"/>
 
 </set>


### PR DESCRIPTION
윌버키우기의 "한 번 더? 윌버를 눌러주세요" 글자가 다시 리셋 하고 나서도 나타나는 버그 고침. 청소년 윌버 먹이는 씨앗의 위치가 애매하여 고침.